### PR TITLE
brew prune is deprecated

### DIFF
--- a/content/posts/2016-12-29-setting-up-a-brand-new-mac-for-development.md
+++ b/content/posts/2016-12-29-setting-up-a-brand-new-mac-for-development.md
@@ -139,7 +139,7 @@ touch .bash_profile
 We'll create a bash alias to combine all the commands to keep Homebrew clean and up to date.
 
 ```bash
-alias brewup='brew update; brew upgrade; brew prune; brew cleanup; brew doctor'
+alias brewup='brew update; brew upgrade; brew cleanup; brew doctor'
 
 ```
 


### PR DESCRIPTION
[From v 1.9.0](https://brew.sh/2019/01/09/homebrew-1.9.0/) brew prune has been replaced by and is now run as part of brew cleanup.

I ran that script while setting up my new MacBook and got this `Error: Unknown command: prune`.
Removing it, no more errors.