### PR TITLE
Fix navbar flashing on theme switch

### DIFF
--- a/src/styles/components/navigation.scss
+++ b/src/styles/components/navigation.scss
@@ -6,7 +6,6 @@
   z-index: 3;
   width: 100%;
   background: white;
-  transition: all 0.3s ease;
 
   .cta {
     display: flex;


### PR DESCRIPTION
Hey Tania!

I noticed that you had set a transition on `.nav` for `all` but not on the other elements of the page. This led to the following 'flashing' behavior when switching the color theme:

![bug-better](https://user-images.githubusercontent.com/19352442/61556203-463b7f80-aa2f-11e9-9cd0-552a0e587d56.gif)

This fix removes the transition:

![bug-fix](https://user-images.githubusercontent.com/19352442/61555661-e1cbf080-aa2d-11e9-9546-47e148192ace.gif)

By the way, do you actually want a transition on all elements, or was that just a leftover line of CSS?

Cheers!