### PR TITLE
code wrap 🌯

### DIFF
--- a/src/styles/components/new-moon.scss
+++ b/src/styles/components/new-moon.scss
@@ -44,7 +44,7 @@ pre code {
   color: $code-font-color;
   direction: ltr;
   text-align: left;
-  white-space: pre;
+  white-space: pre-wrap;
   word-spacing: normal;
   word-break: normal;
   line-height: 1.7;


### PR DESCRIPTION
I noticed in [this article](https://www.taniarascia.com/javascript-mvc-todo-app/) you've got a very long `code` example without any whitespace. This widens the page, causing some of your nav-bar to go off the page in mobile view (360px).

![image](https://user-images.githubusercontent.com/31767869/62742422-d07b7000-ba3e-11e9-92f5-29f4169726b8.png)

Alternatively you could add some [wbr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) tags.