### PR TITLE
Fix typo on meta date post

### DIFF
--- a/content/posts/2019-08-09-node-express-postgresql-heroku.md
+++ b/content/posts/2019-08-09-node-express-postgresql-heroku.md
@@ -1,5 +1,5 @@
 ---
-date: 2019-08-10
+date: 2019-08-09
 title: 'Create and Deploy a Node.js, Express, & PostgreSQL REST API to Heroku'
 template: post
 thumbnail: '../thumbnails/heroku.png'


### PR DESCRIPTION
If you click **edit on github** link in this post, you cannot access the link because the date of the slug is not same as the title **(10 in the meta post and in the github title 09)**