### PR TITLE
update nvm README link

### DIFF
--- a/content/posts/2016-12-29-setting-up-a-brand-new-mac-for-development.md
+++ b/content/posts/2016-12-29-setting-up-a-brand-new-mac-for-development.md
@@ -234,7 +234,7 @@ ssh-keygen -t rsa -b 4096 -C "email@email.com"
 
 ### Node.js
 
-We're going to use [Node Version Manager (nvm)](https://github.com/creationix/nvm/blob/master/README.markdown) to install Node.js.
+We're going to use [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm/blob/master/README.md) to install Node.js.
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash


### PR DESCRIPTION
The [old link](https://github.com/creationix/nvm/blob/master/README.markdown) to nvm README is broken.
I have updated the article with the new link.