### PR TITLE
Fix 'edit mode' method crash

### DIFF
--- a/content/posts/2019-05-16-getting-started-with-vue.md
+++ b/content/posts/2019-05-16-getting-started-with-vue.md
@@ -950,7 +950,6 @@ Editing works, but you still can't cancel the state from updating with this code
 
 ```js
 editMode(employee) {
-  this.editing = id	      
   this.cachedEmployee = Object.assign({}, employee)
   this.editing = employee.id
 },


### PR DESCRIPTION
The 'id' is undefined since it's removed from being a parameter. like it can be seen in the [full demo](https://github.com/taniarascia/vue-tutorial/blob/master/src/components/EmployeeTable.vue#L67)