### PR TITLE
Filter posts server-side to fix posts count

### DIFF
--- a/src/components/PostListing.js
+++ b/src/components/PostListing.js
@@ -8,7 +8,6 @@ export default class PostListing extends Component {
   getPostList() {
     const { postEdges } = this.props
     const postList = postEdges
-      .filter(postEdge => postEdge.node.frontmatter.template === 'post')
       .map(postEdge => {
         return {
           path: postEdge.node.fields.slug,

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -103,7 +103,11 @@ export default class BlogPage extends Component {
 
 export const pageQuery = graphql`
   query BlogQuery {
-    posts: allMarkdownRemark(limit: 2000, sort: { fields: [fields___date], order: DESC }) {
+    posts: allMarkdownRemark(
+      limit: 2000
+      sort: { fields: [fields___date], order: DESC }
+      filter: { frontmatter: { template: { eq: "post" } } }
+    ) {
       edges {
         node {
           fields {


### PR DESCRIPTION
Fixes #50

This adds the fixes described in #50 to filter posts server-side in your GraphQL query instead of in your component.

| Before | After |
| --- | --- |
| ![Screenshot_2019-08-25 Tania Rascia](https://user-images.githubusercontent.com/35560568/63652748-1b49f700-c764-11e9-9e7f-2e8e482b0a57.png) | ![Screenshot_2019-08-25 Tania Rascia(1)](https://user-images.githubusercontent.com/35560568/63652750-213fd800-c764-11e9-8325-712d34fff410.png) |

