### PR TITLE
removes extraneous bracket from code example

### DIFF
--- a/content/posts/2017-12-07-how-to-connect-to-an-api-with-javascript.md
+++ b/content/posts/2017-12-07-how-to-connect-to-an-api-with-javascript.md
@@ -151,7 +151,6 @@ request.open('GET', 'https://ghibliapi.herokuapp.com/films', true)
 
 request.onload = function () {
   // Begin accessing JSON data here
-  }
 }
 
 // Send request


### PR DESCRIPTION
Found an extra bracket in the code example that sets up the `XMLHttpRequest`.