### PR TITLE
Add tooltips to icon links in navigation

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -50,7 +50,7 @@ export default class Navigation extends Component {
               </Link>
             ))}
             <div className="cta">
-              <button className="dark-switcher" onClick={theme.toggleDark}>
+              <button className="dark-switcher" onClick={theme.toggleDark} aria-label="Toggle Dark Mode." title="Toggle Dark Mode">
                 {theme.dark ? (
                   <img src={sun} className="theme-icon" alt="Light Mode" />
                 ) : (
@@ -63,6 +63,8 @@ export default class Navigation extends Component {
               target="_blank"
               rel="noopener noreferrer"
               href="https://ko-fi.com/taniarascia"
+              aria-label="Buy me a coffee!"
+              title="Buy me a coffee!"
             >
               <img src={kofi} alt="Kofi" className="kofi" />
             </a>


### PR DESCRIPTION
Hi!  I really like your site!  The design, layout, and content are really great.  I found it when cassidoo linked to it in her newsletter.  The nav icons were neat, but when I went to mouse over them to figure out what they did, nothing popped up, so I wanted to suggest adding title attributes to them so they show a descriptive tooltip (as well as the accessible counterpart).  No pressure, just thought I would offer 😃