### PR TITLE
Fix the double forward slashes in the SEO url for blog posts paths

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -5,6 +5,7 @@ import config from '../../data/SiteConfig'
 
 export default class SEO extends Component {
   render() {
+    const replacePath = path => (path === `/` ? path : path.replace(/\/$/, ``));
     const { postNode, postPath, postSEO } = this.props
     let title
     let description
@@ -18,7 +19,7 @@ export default class SEO extends Component {
       if (postMeta.thumbnail) {
         image = postMeta.thumbnail.childImageSharp.fixed.src
       }
-      postURL = urljoin(config.siteUrl, config.pathPrefix, postPath)
+      postURL = urljoin(config.siteUrl, replacePath(postPath))
     } else {
       title = config.siteTitle
       description = config.siteDescription


### PR DESCRIPTION
The postUrl in the SEO component will actually generate a double forward slash on all the markdown generated pages. See picture screenshot of one of the latest blog posts from the chrome inspector. This PR is to fix this minor issue. 

<img width="641" alt="Screenshot 2019-10-09 at 1 16 26 AM" src="https://user-images.githubusercontent.com/21316504/66419174-29af5200-ea36-11e9-8b1f-b8664895456f.png">
