### PR TITLE
Edit PHP Basic Router Article - send 404 response code on 404 page

### DIFF
--- a/content/posts/2018-06-21-the-simplest-php-router.md
+++ b/content/posts/2018-06-21-the-simplest-php-router.md
@@ -51,6 +51,7 @@ switch ($request) {
         require __DIR__ . '/views/about.php';
         break;
     default:
+        http_response_code(404);
         require __DIR__ . '/views/404.php';
         break;
 }


### PR DESCRIPTION
Hello,

I came across your PHP Simplest Router article. 

I noticed that when no route is found, only a 404 page will be shown. It would be better if a 404 response code is sent as well..