### PR TITLE
accessibility: made labels explicitly associated with their inputs elements 

### DIFF
--- a/content/posts/2018-08-20-getting-started-with-react.md
+++ b/content/posts/2018-08-20-getting-started-with-react.md
@@ -879,16 +879,18 @@ render() {
 
   return (
     <form>
-      <label>Name</label>
+      <label for="name">Name</label>
       <input
         type="text"
         name="name"
+        id="name"
         value={name}
         onChange={this.handleChange} />
-      <label>Job</label>
+      <label for="job">Job</label>
       <input
         type="text"
         name="job"
+        id="job"
         value={job}
         onChange={this.handleChange} />
     </form>


### PR DESCRIPTION
in the tutorial there is a accessibility anti-pattern, that can be easily fixed. since this is an instructive tutorial on making webpages I think it is important for it to represent inclusive design, especially when it is a very small change.

In the article, the labels arent explicitly associated with their inputs. visually impaired and blind users might not be able to always tell which label is associated with which input, explicitly associating will make sure that their screen reader will present the input field together with its corresponding label. This also makes it easier to use for speech input users.