### PR TITLE
Added missing comma to code example

### DIFF
--- a/content/posts/2019-08-09-node-express-postgresql-heroku.md
+++ b/content/posts/2019-08-09-node-express-postgresql-heroku.md
@@ -443,7 +443,7 @@ With `app.use()`, it will apply to every endpoint, but we can also make certain 
 
 ```js
 const postLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000
+  windowMs: 1 * 60 * 1000,
   max: 1,
 })
 


### PR DESCRIPTION
Simple typo, missing comma in `postLimiter()` code snippet.