### PR TITLE
remove unnecessary prop from EditUserForm

### DIFF
--- a/content/posts/2018-11-07-crud-app-in-react-with-hooks.md
+++ b/content/posts/2018-11-07-crud-app-in-react-with-hooks.md
@@ -640,7 +640,6 @@ Then create the toggle. We'll use a ternary operation to check if the `editing` 
     <div>
       <h2>Edit user</h2>
       <EditUserForm
-        editing={editing}
         setEditing={setEditing}
         currentUser={currentUser}
         updateUser={updateUser}
@@ -681,7 +680,7 @@ useEffect(() => {
 }, [props])
 ```
 
-In the Effect Hook, we create a callback function that updates the `user` state with the new prop thats being sent through. Before, we needed to compare `if (prevProps.currentUser !== this.state.currentUser)`, but with the Effect Hook we can just pass `[props]` through to let it know we're watching props.
+In the Effect Hook, we create a callback function that updates the `user` state with the new prop that's being sent through. Before, we needed to compare `if (prevProps.currentUser !== this.state.currentUser)`, but with the Effect Hook we can just pass `[props]` through to let it know we're watching props.
 
 > Using the `[props]` array is similar to using `componentDidUpdate`. If you're doing a one-time event like `componentDidMount`, you can pass an empty array (`[]`) instead.
 


### PR DESCRIPTION
And add an apostrophe.

I was following along with this tutorial and noticed that `EditUserForm` doesn't make use of `App`'s state variable `editing`.

Thank you for writing these tutorials. There's been so much written on React basics that it's a little overwhelming to start learning. But no one else articulates the material as clearly as you do, so I keep coming back to your articles. Cheers!