### PR TITLE
Fix codeblock error

### DIFF
--- a/content/posts/2016-07-26-how-to-build-a-responsive-image-gallery-with-flexbox.md
+++ b/content/posts/2016-07-26-how-to-build-a-responsive-image-gallery-with-flexbox.md
@@ -191,7 +191,6 @@ Here's an example using the flex grid above and pulling all images from the gall
           ?>
 
     <div class="cell"><a href="<?php echo $image[0]; ?>"><img src="<?php echo $thumb[0]; ?>" class="responsive-image"></a>
-```
 
     			<?php endwhile; ?>
     	</div>


### PR DESCRIPTION
There was an extra set of ```` ``` ```` markers in the source markdown, breaking the final code block in two, and also rendering the concluding paragraph as a code block.