### PR TITLE
Fix Link Property

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -21,29 +21,23 @@ export default class Footer extends Component {
           </a>
         </div>
         <div>
-          <a href="https://github.com/taniarascia" title="Open-source on GitHub">
+          <a href="https://github.com/taniarascia" title="Open-source on GitHub" target="_blank" rel="noopener noreferrer">
             <img
               src={github}
-              target="_blank"
-              rel="noopener noreferrer"
               className="footer-img"
               alt="GitHub"
             />
           </a>
-          <a href="https://www.netlify.com/" title="Hosted by Netlify">
+          <a href="https://www.netlify.com/" title="Hosted by Netlify" target="_blank" rel="noopener noreferrer">
             <img
               src={netlify}
-              target="_blank"
-              rel="noopener noreferrer"
               className="footer-img"
               alt="Netlify"
             />
           </a>
-          <a href="https://www.gatsbyjs.org/" title="Built with Gatsby">
+          <a href="https://www.gatsbyjs.org/" title="Built with Gatsby" target="_blank" rel="noopener noreferrer">
             <img
               src={gatsby}
-              target="_blank"
-              rel="noopener noreferrer"
               className="footer-img"
               alt="Gatsby"
             />


### PR DESCRIPTION
The links in the footer (to the right, GitHub, Netlify & Gatsby) do not open in a new tab.
Looking at your current code I assumed you wanted them to open in a new tab.

This should fix it.
– Eric