### PR TITLE
alignment fix in footer section

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -35,7 +35,7 @@ export default class Footer extends Component {
               alt="Netlify"
             />
           </a>
-          <a href="https://www.gatsbyjs.org/" title="Built with Gatsby" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.gatsbyjs.org/" title="Built with Gatsby" target="_blank" rel="noopener noreferrer" style={{marginRight: 0}}>
             <img
               src={gatsby}
               className="footer-img"


### PR DESCRIPTION
In footer where the symbols are placed, gatsby had a margin-right property applied cause that property is applied to all of anchor tags. This change aligns it perfectly with the view.

I hope you don't mind my inline styles approach