### PR TITLE
Fix layout overflow issue due to long words

### DIFF
--- a/src/styles/components/layout.scss
+++ b/src/styles/components/layout.scss
@@ -17,6 +17,7 @@
   padding: 0 1.5rem;
   margin-left: auto;
   margin-right: auto;
+  overflow-wrap: break-word;
 }
 
 @include small-breakpoint {

--- a/src/styles/components/new-moon.scss
+++ b/src/styles/components/new-moon.scss
@@ -65,6 +65,7 @@ pre code {
   background-color: #333;
   border: 0;
   box-shadow: 2px 4px 25px rgba(0, 0, 0, 0.15);
+  overflow-wrap: normal;
 }
 
 // Keyboard input


### PR DESCRIPTION
Closes #131 

Can't test locally for blog posts, so idk if this breaks anything

Applying it manually via devtools does the trick, though:

![image](https://user-images.githubusercontent.com/19352442/83332422-196c1180-a269-11ea-92c7-4b423c546de6.png)

![image](https://user-images.githubusercontent.com/19352442/83332384-f17cae00-a268-11ea-90ff-2652693c1e25.png)

This also fixes a related issue where your theme toggle button was overflowing on mobile.
