### PR TITLE
fixed: Dark mode not working

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -47,7 +47,7 @@ export default function Nav() {
                   const link = document.createElement('link')
                   link.rel = 'stylesheet'
                   link.id = 'dark-mode'
-                  link.href = '../dark.css'
+                  link.href = '/dark.css'
 
                   head.appendChild(link)
                 }


### PR DESCRIPTION
The dark mode wasn't working after refreshing on category pages.
It was probably because 
```js
link.href = "../dark.css"
```
This was causing an issue on category pages.
ex. `https://www.taniarascia.com/categories/back-end/`

![image](https://user-images.githubusercontent.com/32237558/122933778-91cdd500-d38c-11eb-9820-aaee86a3e2ef.png)


BTW, Your articles are really helpful.