### PR TITLE
remove unnecessary className "post-meta" from header post

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -39,8 +39,7 @@ export default function PostTemplate({ data }) {
               <time>{date}</time>
             </div>
             <h1>{title}</h1>
-            <div className="post-meta">
-              {tags && (
+            {tags && (
                 <div className="tags">
                   {tags.map((tag) => (
                     <Link
@@ -53,7 +52,6 @@ export default function PostTemplate({ data }) {
                   ))}
                 </div>
               )}
-            </div>
           </div>
         </header>
 


### PR DESCRIPTION
Hi Tania,

My greetings from Indonesia. I learned a lot about Gatsbyjs from you. Btw while I was learn this repo, I noticed the className "post-meta" in header post is not in the style.css file, maybe it can be deleted. Cheers!