### PR TITLE
Fix crash on GitHub API rate limit in projects page

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -19,16 +19,20 @@ export default function Projects() {
 
   useEffect(() => {
     async function getStars() {
-      const repos = await fetch(
+      const res = await fetch(
         'https://api.github.com/users/taniarascia/repos?per_page=100'
       )
 
-      return repos.json()
+      if (!res.ok) {
+        throw new Error(`GitHub API error: ${res.status}`)
+      }
+
+      return res.json()
     }
 
     getStars()
       .then((data) => {
-        setRepos(data)
+        setRepos(Array.isArray(data) ? data : [])
       })
       .catch((err) => console.error(err))
   }, [])


### PR DESCRIPTION
## Summary
- GitHub's repos API is unauthenticated and rate-limited to 60 req/hr per IP; hitting the limit returns a 403 with a JSON error object instead of an array
- `repos.find(...)` then threw `e.find is not a function` since `repos` state was set to that error object
- Guard on `res.ok` and coerce non-array responses to `[]` so the page degrades gracefully (star badges just don't render) instead of crashing

Fixes #177

## Test plan
- [ ] Verify page renders without crash when API returns 403
- [ ] Verify star counts still render normally when API succeeds